### PR TITLE
Fix OSClass parsing

### DIFF
--- a/examples/count_hosts_by_os/main.go
+++ b/examples/count_hosts_by_os/main.go
@@ -35,13 +35,16 @@ func countByOS(result *nmap.Run) {
 
 	// Count the number of each OS for all hosts.
 	for _, host := range result.Hosts {
-		for _, class := range host.OS.Classes {
-			switch class.OSFamily() {
-			case osfamily.Linux:
-				linux++
-			case osfamily.Windows:
-				windows++
+		for _, match := range host.OS.Matches {
+			for _, class := range match.Classes {
+				switch class.OSFamily() {
+				case osfamily.Linux:
+					linux++
+				case osfamily.Windows:
+					windows++
+				}
 			}
+
 		}
 	}
 

--- a/examples_test.go
+++ b/examples_test.go
@@ -60,5 +60,5 @@ func ExampleScanner_filters() {
 		len(scanResult.Hosts),
 		scanResult.Stats.Hosts.Total,
 	)
-	// Output: Filtered out hosts 1 / Original number of hosts: 2
+	// Output: Filtered out hosts 0 / Original number of hosts: 2
 }

--- a/tests/xml/scan01.xml
+++ b/tests/xml/scan01.xml
@@ -59,44 +59,55 @@
         <os>
             <portused state="open" proto="tcp" portid="80" />
             <portused state="closed" proto="tcp" portid="443" />
-            <osclass type="software router" vendor="MikroTik" osfamily="RouterOS" osgen="2.X" accuracy="94" />
-            <osclass type="WAP" vendor="Linksys" osfamily="Linux" osgen="2.4.X" accuracy="94" />
-            <osclass type="general purpose" vendor="Linux" osfamily="Linux" osgen="2.4.X" accuracy="94" />
-            <osclass type="general purpose" vendor="Linux" osfamily="Linux" osgen="2.6.X" accuracy="94" />
-            <osclass type="VoIP phone" vendor="WebVOIZE" osfamily="embedded" accuracy="94" />
-            <osclass type="WAP" vendor="D-Link" osfamily="Linux" osgen="2.4.X" accuracy="91" />
-            <osclass type="WAP" vendor="Inventel" osfamily="embedded" accuracy="91" />
-            <osclass type="broadband router" vendor="USRobotics" osfamily="embedded" accuracy="91" />
-            <osclass type="broadband router" vendor="Linux" osfamily="Linux" osgen="2.4.X" accuracy="91" />
-            <osclass type="WAP" vendor="Linux" osfamily="Linux" osgen="2.4.X" accuracy="91" />
-            <osclass type="media device" vendor="Linux" osfamily="Linux" osgen="2.4.X" accuracy="91" />
-            <osclass type="VoIP gateway" vendor="Linux" osfamily="Linux" osgen="2.4.X" accuracy="91" />
-            <osclass type="WAP" vendor="Netgear" osfamily="embedded" accuracy="91" />
-            <osclass type="switch" vendor="QLogic" osfamily="embedded" accuracy="91" />
-            <osclass type="PDA" vendor="Sharp" osfamily="Linux" osgen="2.4.X" accuracy="91" />
-            <osclass type="WAP" vendor="FON" osfamily="Linux" osgen="2.6.X" accuracy="91" />
-            <osclass type="WAP" vendor="FON" osfamily="Linux" osgen="2.4.X" accuracy="90" />
-            <osclass type="WAP" vendor="Belkin" osfamily="embedded" accuracy="90" />
-            <osclass type="WAP" vendor="Asus" osfamily="embedded" accuracy="90" />
-            <osclass type="WAP" vendor="Netgear" osfamily="Linux" osgen="2.4.X" accuracy="90" />
-            <osclass type="printer" vendor="Xerox" osfamily="embedded" accuracy="90" />
-            <osclass type="security-misc" vendor="Aladdin" osfamily="Linux" osgen="2.4.X" accuracy="89" />
-            <osclass type="VoIP gateway" vendor="Occam" osfamily="embedded" accuracy="89" />
-            <osclass type="media device" vendor="Roku" osfamily="embedded" accuracy="89" />
-            <osclass type="WAP" vendor="Siemens" osfamily="Linux" accuracy="89" />
-            <osclass type="broadband router" vendor="3Com" osfamily="Linux" osgen="2.4.X" accuracy="89" />
-            <osclass type="media device" vendor="Dream Multimedia" osfamily="Linux" osgen="2.6.X" accuracy="89" />
-            <osclass type="storage-misc" vendor="Iomega" osfamily="Linux" osgen="2.6.X" accuracy="89" />
-            <osmatch name="MicroTik RouterOS 2.9.46" accuracy="94" line="14788"/>
-            <osmatch name="Linksys WRT54GS WAP (Linux kernel)" accuracy="94" line="8292"/>
-            <osmatch name="Linux 2.4.18 - 2.4.32 (likely embedded)" accuracy="94" line="8499"/>
-            <osmatch name="Linux 2.4.21 - 2.4.33" accuracy="94" line="8624"/>
-            <osmatch name="Linux 2.4.27" accuracy="94" line="8675"/>
-            <osmatch name="Linux 2.4.28 - 2.4.30" accuracy="94" line="8693"/>
-            <osmatch name="Linux 2.6.5 - 2.6.18" accuracy="94" line="11411"/>
-            <osmatch name="Linux 2.6.8" accuracy="94" line="11485"/>
-            <osmatch name="WebVOIZE 120 IP phone" accuracy="94" line="18921"/>
-            <osmatch name="Linux 2.4.2 (Red Hat 7.1)" accuracy="91" line="8533"/>
+            <osmatch name="MicroTik RouterOS 2.9.46" accuracy="94" line="14788">
+                <osclass type="software router" vendor="MikroTik" osfamily="RouterOS" osgen="2.X" accuracy="94" />
+            </osmatch>
+            <osmatch name="Linksys WRT54GS WAP (Linux kernel)" accuracy="94" line="8292">
+                <osclass type="WAP" vendor="Linksys" osfamily="Linux" osgen="2.4.X" accuracy="94" />
+            </osmatch>
+            <osmatch name="Linux 2.4.18 - 2.4.32 (likely embedded)" accuracy="94" line="8499">
+                <osclass type="VoIP phone" vendor="WebVOIZE" osfamily="embedded" accuracy="94" />
+                <osclass type="WAP" vendor="Inventel" osfamily="embedded" accuracy="91" />
+                <osclass type="broadband router" vendor="USRobotics" osfamily="embedded" accuracy="91" />
+                <osclass type="WAP" vendor="Netgear" osfamily="embedded" accuracy="91" />
+                <osclass type="switch" vendor="QLogic" osfamily="embedded" accuracy="91" />
+                <osclass type="broadband router" vendor="Linux" osfamily="Linux" osgen="2.4.X" accuracy="91" />
+                <osclass type="printer" vendor="Xerox" osfamily="embedded" accuracy="90" />
+                <osclass type="media device" vendor="Roku" osfamily="embedded" accuracy="89" />
+            </osmatch>
+            <osmatch name="Linux 2.4.21 - 2.4.33" accuracy="94" line="8624">
+                <osclass type="general purpose" vendor="Linux" osfamily="Linux" osgen="2.4.X" accuracy="94" />
+                <osclass type="WAP" vendor="D-Link" osfamily="Linux" osgen="2.4.X" accuracy="91" />
+                <osclass type="WAP" vendor="Linux" osfamily="Linux" osgen="2.4.X" accuracy="91" />
+                <osclass type="broadband router" vendor="3Com" osfamily="Linux" osgen="2.4.X" accuracy="89" />
+            </osmatch>
+            <osmatch name="Linux 2.4.27" accuracy="94" line="8675">
+                <osclass type="PDA" vendor="Sharp" osfamily="Linux" osgen="2.4.X" accuracy="91" />
+                <osclass type="media device" vendor="Linux" osfamily="Linux" osgen="2.4.X" accuracy="91" />
+            </osmatch>
+            <osmatch name="Linux 2.4.28 - 2.4.30" accuracy="94" line="8693">
+
+            </osmatch>
+            <osmatch name="Linux 2.6.5 - 2.6.18" accuracy="94" line="11411">
+                <osclass type="general purpose" vendor="Linux" osfamily="Linux" osgen="2.6.X" accuracy="94" />
+            </osmatch>
+            <osmatch name="Linux 2.6.8" accuracy="94" line="11485">
+                <osclass type="media device" vendor="Dream Multimedia" osfamily="Linux" osgen="2.6.X" accuracy="89" />
+                <osclass type="storage-misc" vendor="Iomega" osfamily="Linux" osgen="2.6.X" accuracy="89" />
+            </osmatch>
+            <osmatch name="WebVOIZE 120 IP phone" accuracy="94" line="18921">
+                <osclass type="WAP" vendor="FON" osfamily="Linux" osgen="2.6.X" accuracy="91" />
+                <osclass type="VoIP gateway" vendor="Linux" osfamily="Linux" osgen="2.4.X" accuracy="91" />
+                <osclass type="WAP" vendor="FON" osfamily="Linux" osgen="2.4.X" accuracy="90" />
+                <osclass type="WAP" vendor="Belkin" osfamily="embedded" accuracy="90" />
+                <osclass type="WAP" vendor="Asus" osfamily="embedded" accuracy="90" />
+                <osclass type="WAP" vendor="Netgear" osfamily="Linux" osgen="2.4.X" accuracy="90" />
+                <osclass type="VoIP gateway" vendor="Occam" osfamily="embedded" accuracy="89" />
+                <osclass type="WAP" vendor="Siemens" osfamily="Linux" accuracy="89" />
+            </osmatch>
+            <osmatch name="Linux 2.4.2 (Red Hat 7.1)" accuracy="91" line="8533">
+                <osclass type="security-misc" vendor="Aladdin" osfamily="Linux" osgen="2.4.X" accuracy="89" />
+            </osmatch>
             <osfingerprint fingerprint="SCAN(V=4.53%D=1/27%OT=80%CT=443%CU=%PV=N%G=N%TM=479D25ED%P=i686-pc-linux-gnu)&#xa;SEQ(SP=F2%GCD=1%ISR=E9%TI=Z%TS=1C)&#xa;OPS(O1=M5B4ST11NW0%O2=M5B4ST11NW0%O3=M5B4NNT11NW0%O4=M5B4ST11NW0%O5=M5B4ST11NW0%O6=M5B4ST11)&#xa;WIN(W1=16A0%W2=16A0%W3=16A0%W4=16A0%W5=16A0%W6=16A0)&#xa;ECN(R=Y%DF=Y%TG=40%W=16D0%O=M5B4NNSNW0%CC=N%Q=)&#xa;T1(R=Y%DF=Y%TG=40%S=O%A=S+%F=AS%RD=0%Q=)&#xa;T2(R=N)&#xa;T3(R=Y%DF=Y%TG=40%W=16A0%S=O%A=S+%F=AS%O=M5B4ST11NW0%RD=0%Q=)&#xa;T4(R=Y%DF=Y%TG=40%W=0%S=A%A=Z%F=R%O=%RD=0%Q=)&#xa;T5(R=Y%DF=Y%TG=40%W=0%S=Z%A=S+%F=AR%O=%RD=0%Q=)&#xa;T6(R=Y%DF=Y%TG=40%W=0%S=A%A=Z%F=R%O=%RD=0%Q=)&#xa;T7(R=Y%DF=Y%TG=40%W=0%S=Z%A=S+%F=AR%O=%RD=0%Q=)&#xa;U1(R=N)&#xa;IE(R=N)&#xa;" />
         </os>
         <uptime seconds="206" lastboot="Sun Jan 27 21:43:11 2008" />

--- a/xml.go
+++ b/xml.go
@@ -333,7 +333,6 @@ type OS struct {
 	PortsUsed    []PortUsed      `xml:"portused" json:"ports_used"`
 	Matches      []OSMatch       `xml:"osmatch" json:"os_matches"`
 	Fingerprints []OSFingerprint `xml:"osfingerprint" json:"os_fingerprints"`
-	Classes      []OSClass       `xml:"osclass" json:"os_classes"`
 }
 
 // PortUsed is the port used to fingerprint an operating system.
@@ -345,9 +344,10 @@ type PortUsed struct {
 
 // OSMatch contains detailed information regarding an operating system fingerprint.
 type OSMatch struct {
-	Name     string `xml:"name,attr" json:"name"`
-	Accuracy int    `xml:"accuracy,attr" json:"accuracy"`
-	Line     int    `xml:"line,attr" json:"line"`
+	Name     string    `xml:"name,attr" json:"name"`
+	Accuracy int       `xml:"accuracy,attr" json:"accuracy"`
+	Line     int       `xml:"line,attr" json:"line"`
+	Classes  []OSClass `xml:"osclass" json:"os_classes"`
 }
 
 // OSClass contains vendor information about an operating system.

--- a/xml_test.go
+++ b/xml_test.go
@@ -454,7 +454,6 @@ func TestParseRunXML(t *testing.T) {
 									Name:     "Linux 2.4.28 - 2.4.30",
 									Accuracy: 94,
 									Line:     8693,
-									//Classes: []OSClass{},
 								},
 								{
 									Name:     "Linux 2.6.5 - 2.6.18",

--- a/xml_test.go
+++ b/xml_test.go
@@ -186,7 +186,7 @@ func TestToFile(t *testing.T) {
 	err := r.ToFile(os.TempDir() + string(os.PathSeparator) + "toto.txt")
 
 	if err != nil {
-		t.Error("expected ToFile method to properly call ioutil.WriteFile", err)
+		t.Errorf("expected ToFile method to properly call ioutil.WriteFile, got %v", err)
 	}
 }
 

--- a/xml_test.go
+++ b/xml_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -182,9 +183,10 @@ func TestStringMethods(t *testing.T) {
 func TestToFile(t *testing.T) {
 	r := &Run{}
 
-	err := r.ToFile("/tmp/toto.txt")
+	err := r.ToFile(os.TempDir() + string(os.PathSeparator) + "toto.txt")
+
 	if err != nil {
-		t.Error("expected ToFile method to properly call ioutil.WriteFile")
+		t.Error("expected ToFile method to properly call ioutil.WriteFile", err)
 	}
 }
 
@@ -312,243 +314,260 @@ func TestParseRunXML(t *testing.T) {
 									Name:     "MicroTik RouterOS 2.9.46",
 									Accuracy: 94,
 									Line:     14788,
+									Classes: []OSClass{
+										{
+											Vendor:       "MikroTik",
+											OSGeneration: "2.X",
+											Type:         "software router",
+											Accuracy:     94,
+											Family:       "RouterOS",
+										},
+									},
 								},
 								{
 									Name:     "Linksys WRT54GS WAP (Linux kernel)",
 									Accuracy: 94,
 									Line:     8292,
+									Classes: []OSClass{
+										{
+											Vendor:       "Linksys",
+											OSGeneration: "2.4.X",
+											Type:         "WAP",
+											Accuracy:     94,
+											Family:       "Linux",
+										},
+									},
 								},
 								{
 									Name:     "Linux 2.4.18 - 2.4.32 (likely embedded)",
 									Accuracy: 94,
 									Line:     8499,
+									Classes: []OSClass{
+										{
+											Vendor:   "WebVOIZE",
+											Type:     "VoIP phone",
+											Accuracy: 94,
+											Family:   "embedded",
+										},
+										{
+											Vendor:   "Inventel",
+											Type:     "WAP",
+											Accuracy: 91,
+											Family:   "embedded",
+										},
+										{
+											Vendor:   "USRobotics",
+											Type:     "broadband router",
+											Accuracy: 91,
+											Family:   "embedded",
+										},
+										{
+											Vendor:   "Netgear",
+											Type:     "WAP",
+											Accuracy: 91,
+											Family:   "embedded",
+										},
+										{
+											Vendor:   "QLogic",
+											Type:     "switch",
+											Accuracy: 91,
+											Family:   "embedded",
+										},
+										{
+											Vendor:       "Linux",
+											OSGeneration: "2.4.X",
+											Type:         "broadband router",
+											Accuracy:     91,
+											Family:       "Linux",
+										},
+										{
+											Vendor:   "Xerox",
+											Type:     "printer",
+											Accuracy: 90,
+											Family:   "embedded",
+										},
+										{
+											Vendor:   "Roku",
+											Type:     "media device",
+											Accuracy: 89,
+											Family:   "embedded",
+										},
+									},
 								},
 								{
 									Name:     "Linux 2.4.21 - 2.4.33",
 									Accuracy: 94,
 									Line:     8624,
+									Classes: []OSClass{
+										{
+											Vendor:       "Linux",
+											OSGeneration: "2.4.X",
+											Type:         "general purpose",
+											Accuracy:     94,
+											Family:       "Linux",
+										},
+										{
+											Vendor:       "D-Link",
+											OSGeneration: "2.4.X",
+											Type:         "WAP",
+											Accuracy:     91,
+											Family:       "Linux",
+										},
+										{
+											Vendor:       "Linux",
+											OSGeneration: "2.4.X",
+											Type:         "WAP",
+											Accuracy:     91,
+											Family:       "Linux",
+										},
+										{
+											Vendor:       "3Com",
+											OSGeneration: "2.4.X",
+											Type:         "broadband router",
+											Accuracy:     89,
+											Family:       "Linux",
+										},
+									},
 								},
 								{
 									Name:     "Linux 2.4.27",
 									Accuracy: 94,
 									Line:     8675,
+									Classes: []OSClass{
+										{
+											Vendor:       "Sharp",
+											OSGeneration: "2.4.X",
+											Type:         "PDA",
+											Accuracy:     91,
+											Family:       "Linux",
+										},
+										{
+											Vendor:       "Linux",
+											OSGeneration: "2.4.X",
+											Type:         "media device",
+											Accuracy:     91,
+											Family:       "Linux",
+										},
+									},
 								},
 								{
 									Name:     "Linux 2.4.28 - 2.4.30",
 									Accuracy: 94,
 									Line:     8693,
+									//Classes: []OSClass{},
 								},
 								{
 									Name:     "Linux 2.6.5 - 2.6.18",
 									Accuracy: 94,
 									Line:     11411,
+									Classes: []OSClass{
+										{
+											Vendor:       "Linux",
+											OSGeneration: "2.6.X",
+											Type:         "general purpose",
+											Accuracy:     94,
+											Family:       "Linux",
+										},
+									},
 								},
 								{
 									Name:     "Linux 2.6.8",
 									Accuracy: 94,
 									Line:     11485,
+									Classes: []OSClass{
+										{
+											Vendor:       "Dream Multimedia",
+											OSGeneration: "2.6.X",
+											Type:         "media device",
+											Accuracy:     89,
+											Family:       "Linux",
+										},
+										{
+											Vendor:       "Iomega",
+											OSGeneration: "2.6.X",
+											Type:         "storage-misc",
+											Accuracy:     89,
+											Family:       "Linux",
+										},
+									},
 								},
 								{
 									Name:     "WebVOIZE 120 IP phone",
 									Accuracy: 94,
 									Line:     18921,
+									Classes: []OSClass{
+										{
+											Vendor:       "FON",
+											OSGeneration: "2.6.X",
+											Type:         "WAP",
+											Accuracy:     91,
+											Family:       "Linux",
+										},
+										{
+											Vendor:       "Linux",
+											OSGeneration: "2.4.X",
+											Type:         "VoIP gateway",
+											Accuracy:     91,
+											Family:       "Linux",
+										},
+										{
+											Vendor:       "FON",
+											OSGeneration: "2.4.X",
+											Type:         "WAP",
+											Accuracy:     90,
+											Family:       "Linux",
+										},
+										{
+											Vendor:   "Belkin",
+											Type:     "WAP",
+											Accuracy: 90,
+											Family:   "embedded",
+										},
+										{
+											Vendor:   "Asus",
+											Type:     "WAP",
+											Accuracy: 90,
+											Family:   "embedded",
+										},
+										{
+											Vendor:       "Netgear",
+											OSGeneration: "2.4.X",
+											Type:         "WAP",
+											Accuracy:     90,
+											Family:       "Linux",
+										},
+										{
+											Vendor:   "Occam",
+											Type:     "VoIP gateway",
+											Accuracy: 89,
+											Family:   "embedded",
+										},
+										{
+											Vendor:   "Siemens",
+											Type:     "WAP",
+											Accuracy: 89,
+											Family:   "Linux",
+										},
+									},
 								},
 								{
 									Name:     "Linux 2.4.2 (Red Hat 7.1)",
 									Accuracy: 91,
 									Line:     8533,
+									Classes: []OSClass{
+										{
+											Vendor:       "Aladdin",
+											OSGeneration: "2.4.X",
+											Type:         "security-misc",
+											Accuracy:     89,
+											Family:       "Linux",
+										},
+									},
 								},
 							},
 							Fingerprints: []OSFingerprint{
 								{
 									Fingerprint: fingerprint,
-								},
-							},
-							Classes: []OSClass{
-								{
-									Vendor:       "MikroTik",
-									OSGeneration: "2.X",
-									Type:         "software router",
-									Accuracy:     94,
-									Family:       "RouterOS",
-								},
-								{
-									Vendor:       "Linksys",
-									OSGeneration: "2.4.X",
-									Type:         "WAP",
-									Accuracy:     94,
-									Family:       "Linux",
-								},
-								{
-									Vendor:       "Linux",
-									OSGeneration: "2.4.X",
-									Type:         "general purpose",
-									Accuracy:     94,
-									Family:       "Linux",
-								},
-								{
-									Vendor:       "Linux",
-									OSGeneration: "2.6.X",
-									Type:         "general purpose",
-									Accuracy:     94,
-									Family:       "Linux",
-								},
-								{
-									Vendor:   "WebVOIZE",
-									Type:     "VoIP phone",
-									Accuracy: 94,
-									Family:   "embedded",
-								},
-								{
-									Vendor:       "D-Link",
-									OSGeneration: "2.4.X",
-									Type:         "WAP",
-									Accuracy:     91,
-									Family:       "Linux",
-								},
-								{
-									Vendor:   "Inventel",
-									Type:     "WAP",
-									Accuracy: 91,
-									Family:   "embedded",
-								},
-								{
-									Vendor:   "USRobotics",
-									Type:     "broadband router",
-									Accuracy: 91,
-									Family:   "embedded",
-								},
-								{
-									Vendor:       "Linux",
-									OSGeneration: "2.4.X",
-									Type:         "broadband router",
-									Accuracy:     91,
-									Family:       "Linux",
-								},
-								{
-									Vendor:       "Linux",
-									OSGeneration: "2.4.X",
-									Type:         "WAP",
-									Accuracy:     91,
-									Family:       "Linux",
-								},
-								{
-									Vendor:       "Linux",
-									OSGeneration: "2.4.X",
-									Type:         "media device",
-									Accuracy:     91,
-									Family:       "Linux",
-								},
-								{
-									Vendor:       "Linux",
-									OSGeneration: "2.4.X",
-									Type:         "VoIP gateway",
-									Accuracy:     91,
-									Family:       "Linux",
-								},
-								{
-									Vendor:   "Netgear",
-									Type:     "WAP",
-									Accuracy: 91,
-									Family:   "embedded",
-								},
-								{
-									Vendor:   "QLogic",
-									Type:     "switch",
-									Accuracy: 91,
-									Family:   "embedded",
-								},
-								{
-									Vendor:       "Sharp",
-									OSGeneration: "2.4.X",
-									Type:         "PDA",
-									Accuracy:     91,
-									Family:       "Linux",
-								},
-								{
-									Vendor:       "FON",
-									OSGeneration: "2.6.X",
-									Type:         "WAP",
-									Accuracy:     91,
-									Family:       "Linux",
-								},
-								{
-									Vendor:       "FON",
-									OSGeneration: "2.4.X",
-									Type:         "WAP",
-									Accuracy:     90,
-									Family:       "Linux",
-								},
-								{
-									Vendor:   "Belkin",
-									Type:     "WAP",
-									Accuracy: 90,
-									Family:   "embedded",
-								},
-								{
-									Vendor:   "Asus",
-									Type:     "WAP",
-									Accuracy: 90,
-									Family:   "embedded",
-								},
-								{
-									Vendor:       "Netgear",
-									OSGeneration: "2.4.X",
-									Type:         "WAP",
-									Accuracy:     90,
-									Family:       "Linux",
-								},
-								{
-									Vendor:   "Xerox",
-									Type:     "printer",
-									Accuracy: 90,
-									Family:   "embedded",
-								},
-								{
-									Vendor:       "Aladdin",
-									OSGeneration: "2.4.X",
-									Type:         "security-misc",
-									Accuracy:     89,
-									Family:       "Linux",
-								},
-								{
-									Vendor:   "Occam",
-									Type:     "VoIP gateway",
-									Accuracy: 89,
-									Family:   "embedded",
-								},
-								{
-									Vendor:   "Roku",
-									Type:     "media device",
-									Accuracy: 89,
-									Family:   "embedded",
-								},
-								{
-									Vendor:   "Siemens",
-									Type:     "WAP",
-									Accuracy: 89,
-									Family:   "Linux",
-								},
-								{
-									Vendor:       "3Com",
-									OSGeneration: "2.4.X",
-									Type:         "broadband router",
-									Accuracy:     89,
-									Family:       "Linux",
-								},
-								{
-									Vendor:       "Dream Multimedia",
-									OSGeneration: "2.6.X",
-									Type:         "media device",
-									Accuracy:     89,
-									Family:       "Linux",
-								},
-								{
-									Vendor:       "Iomega",
-									OSGeneration: "2.6.X",
-									Type:         "storage-misc",
-									Accuracy:     89,
-									Family:       "Linux",
 								},
 							},
 						},
@@ -1026,6 +1045,28 @@ func compareResults(t *testing.T, expected, got *Run) {
 
 			if !reflect.DeepEqual(expected.Hosts[idx].IPIDSequence, got.Hosts[idx].IPIDSequence) {
 				t.Errorf("unexpected host IPIDSequence, expected %+v got %+v", expected.Hosts[idx].IPIDSequence, got.Hosts[idx].IPIDSequence)
+			}
+
+			if len(expected.Hosts[idx].OS.Matches) != len(got.Hosts[idx].OS.Matches) {
+				t.Errorf("unexpected number of host matches, expected to have %d classes, got %d instead",
+					len(expected.Hosts[idx].OS.Matches), len(got.Hosts[idx].OS.Matches))
+			} else {
+				for i := range expected.Hosts[idx].OS.Matches {
+					if len(expected.Hosts[idx].OS.Matches[i].Classes) != len(got.Hosts[idx].OS.Matches[i].Classes) {
+						t.Errorf("unexpected number of host classes, expected to have %d classes, got %d instead",
+							len(expected.Hosts[idx].OS.Matches[i].Classes), len(got.Hosts[idx].OS.Matches[i].Classes))
+					} else {
+						for j := range expected.Hosts[idx].OS.Matches[i].Classes {
+							if !reflect.DeepEqual(expected.Hosts[idx].OS.Matches[i].Classes[j], got.Hosts[idx].OS.Matches[i].Classes[j]) {
+								t.Errorf("unexpected host os class, expected %+v got %+v", expected.Hosts[idx].OS.Matches[i], got.Hosts[idx].OS.Matches[i].Classes[j])
+							}
+						}
+
+						if !reflect.DeepEqual(expected.Hosts[idx].OS.Matches[i], got.Hosts[idx].OS.Matches[i]) {
+							t.Errorf("unexpected host os match, expected %+v got %+v", expected.Hosts[idx].OS.Matches[i], got.Hosts[idx].OS.Matches[i])
+						}
+					}
+				}
 			}
 
 			if !reflect.DeepEqual(expected.Hosts[idx].OS, got.Hosts[idx].OS) {


### PR DESCRIPTION
As mentioned in #8 the ``osclass`` data is always empty. I checked the [nmap DTD XML specifications](https://nmap.org/data/nmap.dtd), in which it is stated that ``osclass`` is a child of ``osmatch``. Therefore I changed the xml.go accordingly and adapted the xml_test.go as well as the corresponding sample XML data. Additionally I extended the compareResults function in order ease debugging the new struct hierarchy.

As a last point I changed the ``TestToFile`` function to work os independent.

Best regards