### PR TITLE
go install error

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
     <a href="https://godoc.org/github.com/Ullaakut/nmap">
         <img src="https://godoc.org/github.com/Ullaakut/nmap?status.svg" />
     </a>
-    <a href="https://goreportcard.com/report/github.com/ullaakut/nmap">
-        <img src="https://goreportcard.com/badge/github.com/ullaakut/nmap">
+    <a href="https://goreportcard.com/report/github.com/Ullaakut/nmap">
+        <img src="https://goreportcard.com/badge/github.com/Ullaakut/nmap">
     </a>
     <a href="https://travis-ci.org/Ullaakut/nmap">
         <img src="https://travis-ci.org/Ullaakut/nmap.svg?branch=master">

--- a/examples/basic_scan/main.go
+++ b/examples/basic_scan/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/ullaakut/nmap"
+	"github.com/Ullaakut/nmap"
 )
 
 func main() {

--- a/examples/count_hosts_by_os/main.go
+++ b/examples/count_hosts_by_os/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/ullaakut/nmap"
-	osfamily "github.com/ullaakut/nmap/pkg/osfamilies"
+	"github.com/Ullaakut/nmap"
+	osfamily "github.com/Ullaakut/nmap/pkg/osfamilies"
 )
 
 func main() {

--- a/examples/service_detection/main.go
+++ b/examples/service_detection/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/ullaakut/nmap"
+	"github.com/Ullaakut/nmap"
 )
 
 func main() {

--- a/examples/spoof_and_decoys/main.go
+++ b/examples/spoof_and_decoys/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/ullaakut/nmap"
+	"github.com/Ullaakut/nmap"
 )
 
 func main() {

--- a/xml.go
+++ b/xml.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 
-	family "github.com/ullaakut/nmap/pkg/osfamilies"
+	family "github.com/Ullaakut/nmap/pkg/osfamilies"
 )
 
 // Run represents an nmap scanning run.

--- a/xml_test.go
+++ b/xml_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	family "github.com/ullaakut/nmap/pkg/osfamilies"
+	family "github.com/Ullaakut/nmap/pkg/osfamilies"
 )
 
 func TestParseTime(t *testing.T) {
@@ -49,7 +49,6 @@ func TestOSFamily(t *testing.T) {
 		t.Errorf("expected OSClass.OSFamily() to be equal to %v, got %v", family.Linux, osc.OSFamily())
 	}
 }
-
 
 func TestParseTableXML(t *testing.T) {
 	expectedTable := Table{


### PR DESCRIPTION
go 1.11.x 
```shell
../../vendor/github.com/Ullaakut/nmap/xml.go:9:2: cannot find package "github.com/ullaakut/nmap/pkg/osfamilies" in any of:
	/root/.jenkins/jobs/xxxx-2.13.x/workspace/src/idcos.io/xxxx/vendor/github.com/ullaakut/nmap/pkg/osfamilies (vendor tree)
	/opt/golang/go/src/github.com/ullaakut/nmap/pkg/osfamilies (from $GOROOT)
	/root/.jenkins/jobs/xxxx-2.13.x/workspace/src/github.com/ullaakut/nmap/pkg/osfamilies (from $GOPATH)
```