### PR TITLE
Bad PR

### DIFF
--- a/xml.go
+++ b/xml.go
@@ -32,7 +32,12 @@ type Run struct {
 	TaskProgress     []TaskProgress `xml:"taskprogress" json:"task_progress"`
 	TaskEnd          []Task         `xml:"taskend" json:"task_end"`
 
-	rawXML []byte
+	NmapErrors []NmapErrors
+	rawXML     []byte
+}
+
+type NmapErrors struct {
+	Error string
 }
 
 // ToFile writes a Run as XML into the specified file path.
@@ -418,9 +423,10 @@ func (t *Timestamp) UnmarshalXMLAttr(attr xml.Attr) (err error) {
 
 // Parse takes a byte array of nmap xml data and unmarshals it into a
 // Run struct.
-func Parse(content []byte) (*Run, error) {
+func Parse(content []byte, nmapErrors []NmapErrors) (*Run, error) {
 	r := &Run{
-		rawXML: content,
+		rawXML:     content,
+		NmapErrors: nmapErrors,
 	}
 
 	err := xml.Unmarshal(content, r)


### PR DESCRIPTION
Added a NmapErrors Struct for holding errors encountered during the Nmap Scan. Since these errors are specific to nmap, we shouldn't cancel an entire multi target scan just because one host is unresolvable or causing issues.

Additionally, added a utils file that holds a RemoveDuplicates to remove Duplicate nmap errors. Nmap can under certain circumstances return duplicate errors.

This could potentially be further improved to remove duplicates of specific errors.

Example Usage:

```package main

import (
	"context"
	"fmt"
	"log"
	"time"

	"github.com/theseceng/nmap"
)

func main() {
	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
	defer cancel()

	// Equivalent to `/usr/local/bin/nmap -p 80 facebook.com, Bad.Domain.Com.Dsads`,
	// with a 5 minute timeout.
	scanner, err := nmap.NewScanner(
		nmap.WithTargets("facebook.com", "Bad.Domain.Com.Dsads"),
		nmap.WithPorts("80"),
		nmap.WithContext(ctx),
	)
	if err != nil {
		log.Fatalf("unable to create nmap scanner: %v", err)
	}

	// scanner.ShowCommand()

	result, err := scanner.Run()
	if err != nil {
		fmt.Println("Errors encountered")
	}

	for _, e := range result.NmapErrors {
		fmt.Printf("[ ERROR ] - %v\n", e.Error)
	}

	// Use the results to print an example output
	for _, host := range result.Hosts {
		if len(host.Ports) == 0 || len(host.Addresses) == 0 {
			continue
		}

		fmt.Printf("[ SUCCESS ] - Host %q:\n", host.Addresses[0])

		for _, port := range host.Ports {
			fmt.Printf("\t\tPort %d/%s %s %s\n", port.ID, port.Protocol, port.State, port.Service.Name)
		}
	}

	fmt.Printf("Nmap done: %d hosts up scanned in %.2f seconds\n", len(result.Hosts), result.Stats.Finished.Elapsed)
}
```