### PR TITLE
Added nmap --stats-every option

### DIFF
--- a/nmap.go
+++ b/nmap.go
@@ -865,6 +865,14 @@ func WithTimingTemplate(timing Timing) func(*Scanner) {
 	}
 }
 
+// WithStatsEvery periodically prints a timing status message after each interval of time.
+func WithStatsEvery(interval string) func(*Scanner) {
+	return func(s *Scanner) {
+		s.args = append(s.args, "--stats-every")
+		s.args = append(s.args, interval)
+	}
+}
+
 // WithMinHostgroup sets the minimal parallel host scan group size.
 func WithMinHostgroup(size int) func(*Scanner) {
 	return func(s *Scanner) {

--- a/nmap_test.go
+++ b/nmap_test.go
@@ -45,8 +45,8 @@ func TestRun(t *testing.T) {
 		testTimeout     bool
 		compareWholeRun bool
 
-		expectedResult *Run
-		expectedErr    error
+		expectedResult  *Run
+		expectedErr     error
 		expectedNmapErr string
 	}{
 		{
@@ -106,7 +106,7 @@ func TestRun(t *testing.T) {
 			expectedNmapErr: "WARNING: No targets were specified, so 0 hosts scanned.",
 			expectedResult: &Run{
 				Scanner: "nmap",
-				Args: nmapPath + " -T5 -oX -",
+				Args:    nmapPath + " -T5 -oX -",
 			},
 		},
 		{
@@ -1037,7 +1037,7 @@ func TestScriptScan(t *testing.T) {
 					"pass":                  "\",{}=bar\"",
 					"whois":                 "{whodb=nofollow+ripe}",
 					"xmpp-info.server_name": "localhost",
-					"vulns.showall": "",
+					"vulns.showall":         "",
 				}),
 			},
 
@@ -1184,6 +1184,18 @@ func TestTimingAndPerformance(t *testing.T) {
 
 			expectedArgs: []string{
 				"-T4",
+			},
+		},
+		{
+			description: "set stats every",
+
+			options: []func(*Scanner){
+				WithStatsEvery("5s"),
+			},
+
+			expectedArgs: []string{
+				"--stats-every",
+				"5s",
 			},
 		},
 		{


### PR DESCRIPTION
It appears the Nmap library is missing the `--stats-every` option offered by Nmap. This command should be implemented to support additional functionality, especially with the addition of the `RunAsync` command.


Additionally this options allows things such as the below to be more streamline..



[Nmap Asynchronous Progress Stream](https://asciinema.org/a/AVdF5M00bwgeJXCWrMLXAtItE)