### PR TITLE
Fix capitalization of internal package.

### DIFF
--- a/nmap.go
+++ b/nmap.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/Ullaakut/nmap/internal/slices"
+	. "github.com/ullaakut/nmap/internal/slices"
 )
 
 // ScanRunner represents something that can run a scan.


### PR DESCRIPTION
Case sensitive file systems have issues trying to reference the "internal package" of nmap/internal/slices. 

    github.com/ullaakut/nmap (download)
    github.com/Ullaakut/nmap (download)
    go/src/github.com/ullaakut/nmap/nmap.go:13:2: use of internal package github.com/Ullaakut/nmap/internal/slices not allowed

2 separate folders are created with each capitalization and the lower case one can't "use" the uppercase one as an internal package.
