### PR TITLE
Feature/async channels with Progress

### DIFF
--- a/examples/basic_scan_async/main.go
+++ b/examples/basic_scan_async/main.go
@@ -24,30 +24,25 @@ func main() {
 	}
 
 	// Executes asynchronously, allowing results to be streamed in real time.
-	if err := s.RunAsync(); err != nil {
+	nmapResults, nmapErrors, err := s.RunAsync()
+	if err != nil {
 		panic(err)
 	}
-
-	// Connect to stdout of scanner.
-	stdout := s.GetStdout()
-
-	// Connect to stderr of scanner.
-	stderr := s.GetStderr()
 
 	// Goroutine to watch for stdout and print to screen. Additionally it stores
 	// the bytes intoa variable for processiing later.
 	go func() {
-		for stdout.Scan() {
-			fmt.Println(stdout.Text())
-			resultBytes = append(resultBytes, stdout.Bytes()...)
+		for result := range nmapResults {
+			fmt.Print(string(result))
+			resultBytes = append(resultBytes, result...)
 		}
 	}()
 
 	// Goroutine to watch for stderr and print to screen. Additionally it stores
 	// the bytes intoa variable for processiing later.
 	go func() {
-		for stderr.Scan() {
-			errorBytes = append(errorBytes, stderr.Bytes()...)
+		for err := range nmapErrors {
+			errorBytes = append(errorBytes, err...)
 		}
 	}()
 

--- a/examples/basic_scan_async/main.go
+++ b/examples/basic_scan_async/main.go
@@ -17,7 +17,8 @@ func main() {
 	// with a 5 minute timeout.
 	s, err := nmap.NewScanner(
 		nmap.WithTargets("google.com", "facebook.com", "youtube.com"),
-		nmap.WithPorts("80,443,843"),
+		nmap.WithPorts("80,443,843,1-100"),
+		nmap.WithStatsEvery("1s"),
 	)
 	if err != nil {
 		log.Fatalf("unable to create nmap scanner: %v", err)
@@ -30,10 +31,11 @@ func main() {
 	}
 
 	// Goroutine to watch for stdout and print to screen. Additionally it stores
-	// the bytes intoa variable for processiing later.
+	// the bytes into a variable for processing later.
 	go func() {
 		for result := range nmapResults {
-			fmt.Print(string(result))
+			s.Progress(result)
+			//fmt.Print(string(result))
 			resultBytes = append(resultBytes, result...)
 		}
 	}()

--- a/nmap.go
+++ b/nmap.go
@@ -163,7 +163,7 @@ func (s *Scanner) RunAsync() (<-chan []byte, <-chan []byte, error) {
 		}
 	}()
 
-	// Stream stderr to the stderrChannel
+	// Stream error output to the stderrChannel.
 	go func() {
 		defer close(stderrChannel)
 		for {

--- a/nmap.go
+++ b/nmap.go
@@ -129,7 +129,7 @@ func (s *Scanner) RunAsync() (<-chan []byte, <-chan []byte, error) {
 	s.args = append(s.args, "-")
 	s.cmd = exec.Command(s.binaryPath, s.args...)
 
-	// Get CMD Stderr Pipe
+	// Get command error output.
 	stderr, err := s.cmd.StderrPipe()
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to get error output from asynchronous nmap run: %v", err)

--- a/nmap.go
+++ b/nmap.go
@@ -135,7 +135,7 @@ func (s *Scanner) RunAsync() (<-chan []byte, <-chan []byte, error) {
 		return nil, nil, fmt.Errorf("unable to get error output from asynchronous nmap run: %v", err)
 	}
 
-	// Get CMD Stdout Pipe
+	// Get command standard output.
 	stdout, err := s.cmd.StdoutPipe()
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to get standard output from asynchronous nmap run: %v", err)

--- a/nmap.go
+++ b/nmap.go
@@ -148,16 +148,16 @@ func (s *Scanner) RunAsync() (<-chan []byte, <-chan []byte, error) {
 		defer close(stdoutChannel)
 		for {
 			buf := make([]byte, 1024)
-			n, err := stdout.Read(buf)
+			bytesRead, err := stdout.Read(buf)
 			if err != nil {
 				if err != io.EOF {
 					log.Fatal(err)
 				}
-				if n == 0 {
+				if bytesRead == 0 {
 					break
 				}
 			}
-			stdoutChannel <- buf[:n]
+			stdoutChannel <- buf[:bytesRead]
 		}
 	}()
 

--- a/nmap.go
+++ b/nmap.go
@@ -145,7 +145,7 @@ func (s *Scanner) RunAsync() (<-chan []byte, <-chan []byte, error) {
 		return nil, nil, fmt.Errorf("unable to execute asynchronous nmap run: %v", err)
 	}
 
-	// Stream stdout to the stdoutChannel
+	// Stream standard output to the stdoutChannel.
 	go func() {
 		defer close(stdoutChannel)
 		for {


### PR DESCRIPTION
Experimental, how can we improve upon the `Progress` function to not require an argument? Ideally I believe it should be done in this fashion

```go
go scanner.Progress()
```


or


```go
go scanner.Progress(nmapResult Channel)
```

 and the console would stream the progress asynchronously without further code requirements.