### PR TITLE
Added ToReader method for streaming out XML results

### DIFF
--- a/xml.go
+++ b/xml.go
@@ -1,7 +1,9 @@
 package nmap
 
 import (
+	"bytes"
 	"encoding/xml"
+	"io"
 	"io/ioutil"
 	"strconv"
 	"time"
@@ -39,6 +41,11 @@ type Run struct {
 // ToFile writes a Run as XML into the specified file path.
 func (r Run) ToFile(filePath string) error {
 	return ioutil.WriteFile(filePath, r.rawXML, 0666)
+}
+
+// ToReader writes the raw XML into an streamable buffer.
+func (r Run) ToReader() io.Reader {
+	return bytes.NewReader(r.rawXML)
 }
 
 // ScanInfo represents the scan information.
@@ -421,7 +428,7 @@ func (t *Timestamp) UnmarshalXMLAttr(attr xml.Attr) (err error) {
 // Run struct.
 func Parse(content []byte) (*Run, error) {
 	r := &Run{
-		rawXML:     content,
+		rawXML: content,
 	}
 
 	err := xml.Unmarshal(content, r)

--- a/xml_test.go
+++ b/xml_test.go
@@ -312,6 +312,29 @@ func TestToFile(t *testing.T) {
 	}
 }
 
+func TestToReader(t *testing.T) {
+	inputFile := "tests/xml/scan01.xml"
+	rawXML, err := ioutil.ReadFile(inputFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Parse(rawXML)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reader := result.ToReader()
+	byteOutput, err := ioutil.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(byteOutput, result.rawXML) {
+		t.Error("expected ToReader method to return lexicographically identical results")
+	}
+}
+
 func TestTimestampJSONMarshaling(t *testing.T) {
 	dateTime := time.Date(2000, 0, 0, 0, 0, 0, 0, time.UTC)
 	dateBytes := []byte("943920000")


### PR DESCRIPTION
I desired the ability to extract the XML results without having to deal with the filesystem, so I added a method to extract them via `io.Reader`.

I wasn't sure if you were interested in adding a method like this, but I figured I would at least give you the option of adding it.