### PR TITLE
Fix multiple with port calls

### DIFF
--- a/nmap.go
+++ b/nmap.go
@@ -670,7 +670,7 @@ func WithPorts(ports ...string) func(*Scanner) {
 	portList := strings.Join(ports, ",")
 
 	return func(s *Scanner) {
-		//find if any port set
+		// Find if any port is set.
 		var place int = -1
 		for p, value := range s.args {
 			if value == "-p" {
@@ -679,7 +679,7 @@ func WithPorts(ports ...string) func(*Scanner) {
 			}
 		}
 
-		//add ports
+		// Add ports.
 		if place >= 0 {
 			portList = s.args[place+1] + "," + portList
 			s.args[place+1] = portList

--- a/nmap.go
+++ b/nmap.go
@@ -670,8 +670,23 @@ func WithPorts(ports ...string) func(*Scanner) {
 	portList := strings.Join(ports, ",")
 
 	return func(s *Scanner) {
-		s.args = append(s.args, "-p")
-		s.args = append(s.args, portList)
+		//find if any port set
+		var place int = -1
+		for p, value := range s.args {
+			if value == "-p" {
+				place = p
+				break
+			}
+		}
+
+		//add ports
+		if place > 0 {
+			portList = portList + "," + s.args[place+1]
+			s.args[place+1] = portList
+		} else {
+			s.args = append(s.args, "-p")
+			s.args = append(s.args, portList)
+		}
 	}
 }
 

--- a/nmap.go
+++ b/nmap.go
@@ -680,8 +680,8 @@ func WithPorts(ports ...string) func(*Scanner) {
 		}
 
 		//add ports
-		if place > 0 {
-			portList = portList + "," + s.args[place+1]
+		if place >= 0 {
+			portList = s.args[place+1] + "," + portList
 			s.args[place+1] = portList
 		} else {
 			s.args = append(s.args, "-p")

--- a/nmap_test.go
+++ b/nmap_test.go
@@ -935,11 +935,12 @@ func TestPortSpecAndScanOrder(t *testing.T) {
 
 			options: []func(*Scanner){
 				WithPorts("554", "8554"),
+				WithPorts("80-81"),
 			},
 
 			expectedArgs: []string{
 				"-p",
-				"554,8554",
+				"554,8554,80-81",
 			},
 		},
 		{


### PR DESCRIPTION
Hi,

I modified the function "WithPorts" for type Scanner. This will get around the error:
`[Only 1 -p option allowed, separate multiple ranges with commas. QUITTING! EOF]`

Also modified _nmap_test.go_ to check if the new function works.

best regards