### PR TITLE
modify test dependency to /v2, update doc badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@
     <a href="LICENSE">
         <img src="https://img.shields.io/badge/license-MIT-blue.svg?style=flat" />
     </a>
-    <a href="https://godoc.org/github.com/Ullaakut/nmap">
-        <img src="https://godoc.org/github.com/Ullaakut/nmap?status.svg" />
-    </a>
+    <a href="https://pkg.go.dev/github.com/Ullaakut/nmap/v2"><img src="https://pkg.go.dev/badge/github.com/Ullaakut/nmap/v2" alt="PkgGoDev github.com/Ullaakut/nmap/v2"></a>
     <a href="https://goreportcard.com/report/github.com/Ullaakut/nmap">
         <img src="https://goreportcard.com/badge/github.com/Ullaakut/nmap">
     </a>

--- a/go.mod
+++ b/go.mod
@@ -2,3 +2,4 @@ module github.com/Ullaakut/nmap/v2
 
 go 1.15
 
+require github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/xml_test.go
+++ b/xml_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	family "github.com/Ullaakut/nmap/pkg/osfamilies"
+	family "github.com/Ullaakut/nmap/v2/pkg/osfamilies"
 )
 
 func TestParseTime(t *testing.T) {


### PR DESCRIPTION
Even with the v2 module (thanks!), the projects that pull this as dependency still show the previous version as indirect dependency (which is slightly confusing - "why is it still there?") due to the test having the old import.  This PR changes the import in xml_test.go to the `/v2` one, and also updates the documentation badge to point to pkg.go.dev - I believe godoc.org doesn't support the version > v2.

I would appreciate if you could cut yet another (v2.0.2) release after you merge this 😄 

Fixes #57 