### PR TITLE
Feature/run scan with progress sync function

### DIFF
--- a/examples/basic_scan_progress/main.go
+++ b/examples/basic_scan_progress/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"github.com/Ullaakut/nmap/v2"
+	"log"
+	"time"
+)
+
+func main() {
+	scanner, err := nmap.NewScanner(
+		nmap.WithTargets("localhost"),
+		nmap.WithPorts("1-4000"),
+		nmap.WithServiceInfo(),
+		nmap.WithVerbosity(3),
+	)
+	if err != nil {
+		log.Fatalf("unable to create nmap scanner: %v", err)
+	}
+
+	progress := make(chan float32, 1)
+
+	// Function to listen and print the progress
+	go func() {
+		for p := range progress {
+			fmt.Printf("Progress: %v %%\n", p)
+		}
+	}()
+
+	result, _, err := scanner.RunWithProgress(progress)
+	if err != nil {
+		log.Fatalf("unable to run nmap scan: %v", err)
+	}
+
+	time.Sleep(2 * time.Second)
+
+	fmt.Printf("Nmap done: %d hosts up scanned in %.2f seconds\n", len(result.Hosts), result.Stats.Finished.Elapsed)
+}

--- a/examples/basic_scan_progress/main.go
+++ b/examples/basic_scan_progress/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/Ullaakut/nmap/v2"
 	"log"
-	"time"
 )
 
 func main() {
@@ -31,8 +30,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("unable to run nmap scan: %v", err)
 	}
-
-	time.Sleep(2 * time.Second)
 
 	fmt.Printf("Nmap done: %d hosts up scanned in %.2f seconds\n", len(result.Hosts), result.Stats.Finished.Elapsed)
 }

--- a/examples/basic_scan_progress/main.go
+++ b/examples/basic_scan_progress/main.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/Ullaakut/nmap/v2"
 	"log"
+
+	"github.com/Ullaakut/nmap/v2"
 )
 
 func main() {

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/nmap.go
+++ b/nmap.go
@@ -182,7 +182,7 @@ func (s *Scanner) RunWithProgress(liveProgress chan<- float32) (result *Run, war
 			default:
 				time.Sleep(time.Second)
 				result, _ := Parse(stdout.Bytes())
-				if len(result.TaskProgress) > 0{
+				if len(result.TaskProgress) > 0 {
 					liveProgress <- result.TaskProgress[len(result.TaskProgress)-1].Percent
 				}
 			}

--- a/nmap.go
+++ b/nmap.go
@@ -171,7 +171,7 @@ func (s *Scanner) RunWithProgress(liveProgress chan<- float32) (result *Run, war
 		done <- cmd.Wait()
 	}()
 
-	// Make goroutine to stream the progress
+	// Make goroutine to check the progress every second
 	// Listening for channel doneProgress
 	go func() {
 		for {

--- a/tests/scripts/fake_nmap_delay.sh
+++ b/tests/scripts/fake_nmap_delay.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+input=$1
+while IFS= read -r line
+do
+  echo "$line"
+  sleep .5
+done < "$input"


### PR DESCRIPTION
Hi,

I added a new function `RunWithProgress(liveProgress chan<- float32)` that gets a channel and send through the current scan progress.

- The function is based on the synchronized `Run()` function.
- It uses nmap parameter `--stats-every 1s` to constantly output **this:**
```xml
<taskprogress task="Service scan" time="1604312895" percent="85.71" remaining="6" etc="1604312901"/>
```

- [x] Maybe add unit test
- [x] Check how to only parse `<taskprogress>` into an array instead of whole stdout in line `184`
- [x] Make suggestions for improvement

@Ullaakut What do you think about this new feature?