### PR TITLE
Fix run with progress and add new Run function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,12 @@ dist: trusty
 sudo: required
 language: go
 
+go:
+- 1.15.x
+
 before_install:
 - sudo apt-get install -y nmap
+- go mod tidy
 - go get github.com/mattn/goveralls
 
 script:

--- a/examples/basic_scan_streamer_interface/main.go
+++ b/examples/basic_scan_streamer_interface/main.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"strings"
+
+	"github.com/Ullaakut/nmap/v2"
+)
+
+type CustomType struct {
+	nmap.Streamer
+	File string
+}
+
+// Write is a function that handles the normal nmap stdout
+func (c *CustomType) Write(d []byte) (int, error) {
+	var err error
+	lines := string(d)
+
+	if strings.Contains(lines, "Stats: ") {
+		fmt.Print(lines)
+	}
+	return len(d), err
+}
+
+// Bytes returns scan result bytes
+func (c *CustomType) Bytes() []byte {
+	data, err := ioutil.ReadFile(c.File)
+	if err != nil {
+		data = append(data, "\ncould not read File"...)
+	}
+	return data
+}
+
+func main() {
+	cType := &CustomType{
+		File:     "/tmp/output.xml",
+	}
+	scanner, err := nmap.NewScanner(
+		nmap.WithTargets("localhost"),
+		nmap.WithPorts("1-4000"),
+		nmap.WithServiceInfo(),
+		nmap.WithVerbosity(3),
+	)
+	if err != nil {
+		log.Fatalf("unable to create nmap scanner: %v", err)
+	}
+
+	warnings, err := scanner.RunWithStreamer(cType, cType.File)
+	if err != nil {
+		log.Fatalf("unable to run nmap scan: %v", err)
+	}
+
+	fmt.Printf("Nmap warnings: %v\n", warnings)
+
+	result, err := nmap.Parse(cType.Bytes())
+	if err != nil {
+		log.Fatalf("unable to parse nmap output: %v", err)
+	}
+
+	fmt.Printf("Nmap done: %d hosts up scanned in %.2f seconds\n", len(result.Hosts), result.Stats.Finished.Elapsed)
+}

--- a/examples/basic_scan_streamer_interface/main.go
+++ b/examples/basic_scan_streamer_interface/main.go
@@ -16,18 +16,17 @@ type CustomType struct {
 	File string
 }
 
-// Write is a function that handles the normal nmap stdout
+// Write is a function that handles the normal nmap stdout.
 func (c *CustomType) Write(d []byte) (int, error) {
-	var err error
 	lines := string(d)
 
 	if strings.Contains(lines, "Stats: ") {
 		fmt.Print(lines)
 	}
-	return len(d), err
+	return len(d), nil
 }
 
-// Bytes returns scan result bytes
+// Bytes returns scan result bytes.
 func (c *CustomType) Bytes() []byte {
 	data, err := ioutil.ReadFile(c.File)
 	if err != nil {

--- a/examples/basic_scan_streamer_interface/main.go
+++ b/examples/basic_scan_streamer_interface/main.go
@@ -9,6 +9,8 @@ import (
 	"github.com/Ullaakut/nmap/v2"
 )
 
+// CustomType is your custom type in code.
+// You just have to make it a Streamer.
 type CustomType struct {
 	nmap.Streamer
 	File string
@@ -36,7 +38,7 @@ func (c *CustomType) Bytes() []byte {
 
 func main() {
 	cType := &CustomType{
-		File:     "/tmp/output.xml",
+		File: "/tmp/output.xml",
 	}
 	scanner, err := nmap.NewScanner(
 		nmap.WithTargets("localhost"),

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module github.com/Ullaakut/nmap/v2
 
 go 1.15
 
-require github.com/stretchr/testify v1.6.1
+require (
+	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.6.1
+	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
+)

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,14 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/nmap.go
+++ b/nmap.go
@@ -294,11 +294,11 @@ func (s *Scanner) RunWithStreamer(stream Streamer, file string) (warnings []stri
 	// Prepare nmap process
 	cmd := exec.CommandContext(s.ctx, s.binaryPath, s.args...)
 
-	// write stderr to buffer
+	// Write stderr to buffer
 	stderrBuf := bytes.Buffer{}
 	cmd.Stderr = &stderrBuf
 
-	// connect to the StdoutPipe
+	// Connect to the StdoutPipe
 	stdoutIn, err := cmd.StdoutPipe()
 	if err != nil {
 		return warnings, errors.WithMessage(err, "connect to StdoutPipe failed")
@@ -310,7 +310,7 @@ func (s *Scanner) RunWithStreamer(stream Streamer, file string) (warnings []stri
 		return warnings, errors.WithMessage(err, "start command failed")
 	}
 
-	// copy stdout to pipe
+	// Copy stdout to pipe
 	g, _ := errgroup.WithContext(s.ctx)
 	g.Go(func() error {
 		_, err = io.Copy(stdout, stdoutIn)
@@ -326,7 +326,7 @@ func (s *Scanner) RunWithStreamer(stream Streamer, file string) (warnings []stri
 	// Process nmap stderr output containing none-critical errors and warnings
 	// Everyone needs to check whether one or some of these warnings is a hard issue in their use case
 	if stderrBuf.Len() > 0 {
-		for _,v := range strings.Split(strings.Trim(stderrBuf.String(), "\n"), "\n"){
+		for _, v := range strings.Split(strings.Trim(stderrBuf.String(), "\n"), "\n") {
 			warnings = append(warnings, v)
 		}
 	}

--- a/nmap.go
+++ b/nmap.go
@@ -7,12 +7,13 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
-	"github.com/pkg/errors"
-	"golang.org/x/sync/errgroup"
 	"io"
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 )
 
 // ScanRunner represents something that can run a scan.
@@ -119,7 +120,7 @@ func (s *Scanner) Run() (result *Run, warnings []string, err error) {
 			warnings = strings.Split(strings.Trim(stderr.String(), "\n"), "\n")
 		}
 
-		// Check for warnings that will inevitable lead to parsing errors, hence, have priority.
+		// Check for warnings that will inevitably lead to parsing errors, hence, have priority.
 		if err := analyzeWarnings(warnings); err != nil {
 			return nil, warnings, err
 		}
@@ -232,7 +233,7 @@ func (s *Scanner) RunWithProgress(liveProgress chan<- float32) (result *Run, war
 			warnings = strings.Split(strings.Trim(stderr.String(), "\n"), "\n")
 		}
 
-		// Check for warnings that will inevitable lead to parsing errors, hence, have priority.
+		// Check for warnings that will inevitably lead to parsing errors, hence, have priority.
 		if err := analyzeWarnings(warnings); err != nil {
 			return nil, warnings, err
 		}
@@ -322,7 +323,7 @@ func (s *Scanner) RunWithStreamer(stream Streamer, file string) (warnings []stri
 		}
 	}
 
-	// Check for warnings that will inevitable lead to parsing errors, hence, have priority.
+	// Check for warnings that will inevitably lead to parsing errors, hence, have priority.
 	if err := analyzeWarnings(warnings); err != nil {
 		return warnings, err
 	}
@@ -419,7 +420,7 @@ func choosePorts(result *Run, filter func(Port) bool) *Run {
 }
 
 func analyzeWarnings(warnings []string) error {
-	// Check for warnings that will inevitable lead to parsing errors, hence, have priority.
+	// Check for warnings that will inevitably lead to parsing errors, hence, have priority.
 	for _, warning := range warnings {
 		switch {
 		case strings.Contains(warning, "Malloc Failed!"):

--- a/nmap.go
+++ b/nmap.go
@@ -317,11 +317,12 @@ func (s *Scanner) RunWithStreamer(stream Streamer, file string) (warnings []stri
 		return err
 	})
 
-	if err := cmd.Wait(); err != nil {
-		warnings = append(warnings, errors.WithMessage(err, "nmap command failed").Error())
-	}
+	cmdErr := cmd.Wait()
 	if err := g.Wait(); err != nil {
 		warnings = append(warnings, errors.WithMessage(err, "read from stdout failed").Error())
+	}
+	if cmdErr != nil {
+		return warnings, errors.WithMessage(err, "nmap command failed")
 	}
 	// Process nmap stderr output containing none-critical errors and warnings.
 	// Everyone needs to check whether one or some of these warnings is a hard issue in their use case.

--- a/nmap_test.go
+++ b/nmap_test.go
@@ -271,10 +271,10 @@ func TestRunWithProgress(t *testing.T) {
 				WithCustomArguments("tests/xml/scan_base.xml"),
 			},
 
-			compareWholeRun: true,
-			expectedResult: r,
+			compareWholeRun:  true,
+			expectedResult:   r,
 			expectedProgress: []float32{56.66, 81.95, 87.84, 94.43, 97.76, 97.76},
-			expectedErr: nil,
+			expectedErr:      nil,
 		},
 	}
 

--- a/nmap_test.go
+++ b/nmap_test.go
@@ -15,17 +15,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type TestStreamer struct {
+type testStreamer struct {
 	Streamer
 }
 
 // Write is a function that handles the normal nmap stdout.
-func (c *TestStreamer) Write(d []byte) (int, error) {
+func (c *testStreamer) Write(d []byte) (int, error) {
 	return len(d), nil
 }
 
 // Bytes returns scan result bytes.
-func (c *TestStreamer) Bytes() []byte {
+func (c *testStreamer) Bytes() []byte {
 	return []byte{}
 }
 
@@ -322,7 +322,7 @@ func TestRunWithProgress(t *testing.T) {
 }
 
 func TestRunWithStreamer(t *testing.T) {
-	streamer := &TestStreamer{}
+	streamer := &testStreamer{}
 
 	tests := []struct {
 		description string
@@ -2127,7 +2127,7 @@ func TestAnalyzeWarnings(t *testing.T) {
 	}{
 		{
 			description: "Find no error warning",
-			warnings: []string{"NoWaring", "NoWarning"},
+			warnings: []string{"NoWarning", "NoWarning"},
 			expectedErr: nil,
 		},
 		{


### PR DESCRIPTION
Hi,

I fixed the function RunWithProgress because there was a memory leak (line 212) when cancelling the context before the scan was finished.
I also added a new "Run" type of funtion (RunWithStreamer) that writes the xml-output directly to a file.


- This will prevent huge memory usage when running long scans.
- It also enables the standard nmap output to monitor the current nmap status.
- When the scan is finished the file can be parsed.

There is also an example showing how to run this type of scan.

Best regards!

P.S.
I would also appreciate a new tag :-)