### PR TITLE
Add --unique and --script-timeout flags

### DIFF
--- a/iflist_test.go
+++ b/iflist_test.go
@@ -1,9 +1,10 @@
 package nmap
 
 import (
-	"github.com/stretchr/testify/assert"
 	"net"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestScanner_GetInterfaceList(t *testing.T) {

--- a/nmap.go
+++ b/nmap.go
@@ -532,6 +532,17 @@ func WithRandomTargets(randomTargets int) Option {
 	}
 }
 
+// WithUnique makes each address be scanned only once.
+// The default behavior is to scan each address as many times
+// as it is specified in the target list, such as when network
+// ranges overlap or different hostnames resolve to the same
+// address.
+func WithUnique() Option {
+	return func(s *Scanner) {
+		s.args = append(s.args, "--unique")
+	}
+}
+
 /*** Host discovery ***/
 
 // WithListScan sets the discovery mode to simply list the targets to scan and not scan them.
@@ -1072,6 +1083,16 @@ func WithScriptTrace() Option {
 func WithScriptUpdateDB() Option {
 	return func(s *Scanner) {
 		s.args = append(s.args, "--script-updatedb")
+	}
+}
+
+// WithScriptTimeout sets the script timeout.
+func WithScriptTimeout(timeout time.Duration) Option {
+	milliseconds := timeout.Round(time.Nanosecond).Nanoseconds() / 1000000
+
+	return func(s *Scanner) {
+		s.args = append(s.args, "--script-timeout")
+		s.args = append(s.args, fmt.Sprintf("%dms", int(milliseconds)))
 	}
 }
 

--- a/nmap_test.go
+++ b/nmap_test.go
@@ -549,6 +549,17 @@ func TestTargetSpecification(t *testing.T) {
 			},
 		},
 		{
+			description: "unique addresses",
+
+			options: []Option{
+				WithUnique(),
+			},
+
+			expectedArgs: []string{
+				"--unique",
+			},
+		},
+		{
 			description: "target exclusion",
 
 			options: []Option{
@@ -1339,6 +1350,18 @@ func TestScriptScan(t *testing.T) {
 
 			expectedArgs: []string{
 				"--script-updatedb",
+			},
+		},
+		{
+			description: "set script timeout",
+
+			options: []Option{
+				WithScriptTimeout(40 * time.Second),
+			},
+
+			expectedArgs: []string{
+				"--script-timeout",
+				"40000ms",
 			},
 		},
 	}


### PR DESCRIPTION
## Goal of this PR

Fixes #97 

Adds support for the flags found at:

* [`--unique`](https://nmap.org/book/man-target-specification.html)
* [`--script-timeout`](https://nmap.org/book/man-performance.html)

And adds unit tests.