### PR TITLE
Not forcing normal nmap output to stdout

### DIFF
--- a/nmap.go
+++ b/nmap.go
@@ -106,9 +106,9 @@ func (s *Scanner) Run() (result *Run, warnings *[]string, err error) {
 	args := s.args
 
 	// Write XML to standard output.
-	// If toFile is set then write XML to file and normal nmap output to stdout.
+	// If toFile is set then write XML to file.
 	if s.toFile != nil {
-		args = append(args, "-oX", *s.toFile, "-oN", "-")
+		args = append(args, "-oX", *s.toFile)
 	} else {
 		args = append(args, "-oX", "-")
 	}


### PR DESCRIPTION
Since nmap defaults to writing the normal nmap output to stdout, there is no need to force it when writing the XML output to a file.