### PR TITLE
Add Host timedout field

### DIFF
--- a/tests/xml/scan_base.xml
+++ b/tests/xml/scan_base.xml
@@ -35,7 +35,7 @@
     <taskend task="System CNAME DNS resolution of 8 hosts." time="1201481086" />
     <taskbegin task="SCRIPT ENGINE" time="1201481086" />
     <taskend task="SCRIPT ENGINE" time="1201481197" />
-    <host>
+    <host starttime="1684341000" endtime="1684342000" timedout="true">
         <status state="up" reason="reset"/>
         <address addr="66.35.250.168" addrtype="ipv4" />
         <hostnames>

--- a/xml.go
+++ b/xml.go
@@ -115,6 +115,7 @@ type Host struct {
 	IPIDSequence  IPIDSequence  `xml:"ipidsequence" json:"ip_id_sequence"`
 	OS            OS            `xml:"os" json:"os"`
 	StartTime     Timestamp     `xml:"starttime,attr,omitempty" json:"start_time"`
+	TimedOut      bool          `xml:"timedout,attr,omitempty" json:"timed_out"`
 	Status        Status        `xml:"status" json:"status"`
 	TCPSequence   TCPSequence   `xml:"tcpsequence" json:"tcp_sequence"`
 	TCPTSSequence TCPTSSequence `xml:"tcptssequence" json:"tcp_ts_sequence"`

--- a/xml_test.go
+++ b/xml_test.go
@@ -438,6 +438,9 @@ func TestParseRunXML(t *testing.T) {
 				},
 				Hosts: []Host{
 					{
+						StartTime: Timestamp(time.Unix(1684341000, 0)),
+						EndTime:   Timestamp(time.Unix(1684342000, 0)),
+						TimedOut:  true,
 						IPIDSequence: IPIDSequence{
 							Class:  "All zeros",
 							Values: "0,0,0,0,0,0",
@@ -1179,6 +1182,10 @@ func compareResults(t *testing.T, expected, got *Run) {
 				t.Errorf("unexpected host distance, expected %+v got %+v", expected.Hosts[idx].Distance, got.Hosts[idx].Distance)
 			}
 
+			if !reflect.DeepEqual(expected.Hosts[idx].EndTime, got.Hosts[idx].EndTime) {
+				t.Errorf("unexpected host end time, expected %+v got %+v", expected.Hosts[idx].EndTime, got.Hosts[idx].EndTime)
+			}
+
 			if !reflect.DeepEqual(expected.Hosts[idx].ExtraPorts, got.Hosts[idx].ExtraPorts) {
 				t.Errorf("unexpected host extra ports, expected %+v got %+v", expected.Hosts[idx].ExtraPorts, got.Hosts[idx].ExtraPorts)
 			}
@@ -1231,6 +1238,10 @@ func compareResults(t *testing.T, expected, got *Run) {
 
 			if !reflect.DeepEqual(expected.Hosts[idx].StartTime, got.Hosts[idx].StartTime) {
 				t.Errorf("unexpected host start time, expected %+v got %+v", expected.Hosts[idx].StartTime, got.Hosts[idx].StartTime)
+			}
+
+			if !reflect.DeepEqual(expected.Hosts[idx].TimedOut, got.Hosts[idx].TimedOut) {
+				t.Errorf("unexpected host timedout, expected %+v got %+v", expected.Hosts[idx].TimedOut, got.Hosts[idx].TimedOut)
 			}
 
 			if !reflect.DeepEqual(expected.Hosts[idx].Status, got.Hosts[idx].Status) {


### PR DESCRIPTION
Hello, 

Here is a small PR that adds a missing field in the `Host` struct so that we can use that field in go code. My goal is to be able to differentiate between a successful complete scan and a partial scan with timeouts.

In version [Nmap 7.92 [2021-08-07]](https://nmap.org/changelog.html#7.92) a new xml attribute was added to the <Host> tag.

See link to [changelog](https://nmap.org/changelog.html#7.92:~:text=If%20a%20host%20times%20out%2C%20the%20XML%20%3Chost%3E%20element%20will%20have%20the%20attribute%20timedout%3D%22true%22%20and%20the%20host%27s%20timing%20info%20(srtt%20etc.)%20will%20still%20be%20printed.) 

```
If a host times out, the XML <host> element will have the attribute timedout="true" and the host's timing info (srtt etc.) will still be printed.
```

This field is only populated when a host timed out while using the `WithHostTimeout (--host-timeout)` option.

Thanks!


