### PR TITLE
fix: remove outdated example test

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -31,37 +31,3 @@ func ExampleScanner_simple() {
 	)
 	// Output: Scan successful: 3 hosts up
 }
-
-// A scanner can be given custom idiomatic filters for both hosts
-// and ports.
-func ExampleScanner_filters() {
-	s, err := NewScanner(
-		context.Background(),
-		WithTargets("google.com", "facebook.com"),
-		WithPorts("843"),
-		WithFilterHost(func(h Host) bool {
-			// Filter out hosts with no open ports.
-			for idx := range h.Ports {
-				if h.Ports[idx].Status() == "closed" {
-					return true
-				}
-			}
-			return false
-		}),
-	)
-	if err != nil {
-		log.Fatalf("unable to create nmap scanner: %v", err)
-	}
-
-	scanResult, _, err := s.Run()
-	if err != nil {
-		log.Fatalf("nmap encountered an error: %v", err)
-	}
-
-	fmt.Printf(
-		"Filtered out hosts %d / Original number of hosts: %d\n",
-		len(scanResult.Hosts),
-		scanResult.Stats.Hosts.Total,
-	)
-	// Output: Filtered out hosts 1 / Original number of hosts: 2
-}


### PR DESCRIPTION
## Goal of this PR

Removes outdated test which relied on google.com and facebook.com having specific ports closed instead of filtered which is no longer the case. Was obviously dumb in retrospect 🤷 

Will then fix #134 by publishing a new version.