### PR TITLE
WithOSDetection: check for root privileges warning -- fix unclear error status

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -19,6 +19,9 @@ var (
 	// ErrParseOutput means that nmap's output was not parsed successfully.
 	ErrParseOutput = errors.New("unable to parse nmap output, see warnings for details")
 
+	// ErrRequiresRoot means this feature requires root privileges (e.g. OS detection)
+	ErrRequiresRoot = errors.New("this feature requires root privileges")
+
 	// ErrResolveName means that Nmap could not resolve a name.
 	ErrResolveName = errors.New("nmap could not resolve a name")
 )


### PR DESCRIPTION
Improve error handling when `WithOSDetection` is called without being root

## Example Test CLI 
https://gist.github.com/tonymet/6107b994863d8ba8f6e0c062ae026b27

```
git clone git@gist.github.com:6107b994863d8ba8f6e0c062ae026b27.git node-go-test
cd node-go-test
 go run . --target 192.168.10.1 
2025/01/04 17:21:09 unable to run nmap scan: this feature requires root privileges
2025/01/04 17:21:09 Warnings: 
 &[TCP/IP fingerprinting (for OS scan) requires root privileges.]
Nmap done: 0 hosts up scanned in 0.000000 seconds

```


## STEPS TO REPEAT
1. create a scanner WithOSDetection() (see gist)
2. inspect err or warnings
```
	scanner, err := nmap.NewScanner(
		ctx,
		nmap.WithTargets(optTargets...),
		nmap.WithPorts(optPorts),
		nmap.WithOSDetection(),
	)
```

## BEFORE

```
2025/01/04 17:15:08 unable to run nmap scan: exit status 1
```

## AFTER 
```
2025/01/04 17:15:28 unable to run nmap scan: this feature requires root privileges
2025/01/04 17:15:28 Warnings: 
 &[TCP/IP fingerprinting (for OS scan) requires root privileges.]
```