### PR TITLE
Fixed issue with latest return error handling

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -25,7 +25,7 @@ var (
 	// ErrParseOutput means that nmap's output was not parsed successfully.
 	ErrParseOutput = errors.New("unable to parse nmap output, see warnings for details")
 
-	// ErrRequiresRoot means that a (e.g. OS detection) feature requires root privileges
+	// ErrRequiresRoot means that a feature (e.g. OS detection) requires root privileges
 	ErrRequiresRoot = errors.New("this feature requires root privileges")
 
 	// ErrResolveName means that Nmap could not resolve a name.

--- a/errors.go
+++ b/errors.go
@@ -10,8 +10,14 @@ var (
 	// the nmap binary is present in the user's $PATH.
 	ErrNmapNotInstalled = errors.New("nmap binary was not found")
 
-	// ErrScanTimeout means that the provided context was done before the scanner finished its scan.
+	// ErrScanTimeout means that the provided context timeout triggered done before the scanner finished its scan.
+	// This error will *not* be returned if a scan timeout was configured using Nmap arguments, since Nmap would
+	// gracefully shut down it's scanning and return some results in that case.
 	ErrScanTimeout = errors.New("nmap scan timed out")
+
+	// ErrScanInterrupt means that the scan was interrupted before the scanner finished its scan.
+	// Reasons for this error might be sigint or a cancelled context.
+	ErrScanInterrupt = errors.New("nmap scan interrupted")
 
 	// ErrMallocFailed means that nmap crashed due to insufficient memory, which may happen on large target networks.
 	ErrMallocFailed = errors.New("malloc failed, probably out of space")
@@ -19,7 +25,7 @@ var (
 	// ErrParseOutput means that nmap's output was not parsed successfully.
 	ErrParseOutput = errors.New("unable to parse nmap output, see warnings for details")
 
-	// ErrRequiresRoot means this feature requires root privileges (e.g. OS detection)
+	// ErrRequiresRoot means that a (e.g. OS detection) feature requires root privileges
 	ErrRequiresRoot = errors.New("this feature requires root privileges")
 
 	// ErrResolveName means that Nmap could not resolve a name.

--- a/nmap.go
+++ b/nmap.go
@@ -262,27 +262,20 @@ func (s *Scanner) processNmapResult(result *Run, warnings *[]string, stdout, std
 		return errStdout
 	}
 
+	// Check for errors indicated by context or return code.
 	switch {
-		case errors.Is(s.ctx.Err(), context.DeadlineExceeded):
-			return ErrScanTimeout
-		case errors.Is(s.ctx.Err(), context.Canceled):
-			return ErrScanInterrupt
-		case errStatus.Error() == "exit status 0xc000013a" || // Exit code of ctrl+c on Windows
-			errStatus.Error() == "exit status 130": // Exit code of ctrl+c on Linux
-			return ErrScanInterrupt
-		}
-	}
-
-		// Return scan interrupt error as the Nmap process was interrupted by ctrl+c.
-		if errStatus.Error() == "exit status 0xc000013a" || // Exit code of ctrl+c on Windows
-			errStatus.Error() == "exit status 130" { // Exit code of ctrl+c on Linux
-			return ErrScanInterrupt
-		}
-
-		// TODO: Add clauses for other known exit codes we might want to define.
-
-		// Return generic error.
+	case errors.Is(s.ctx.Err(), context.DeadlineExceeded):
+		return ErrScanTimeout
+	case errors.Is(s.ctx.Err(), context.Canceled):
+		return ErrScanInterrupt
+	case errStatus.Error() == "exit status 0xc000013a": // Exit code for ctrl+c on Windows
+		return ErrScanInterrupt
+	case errStatus.Error() == "exit status 130": // Exit code for ctrl+c on Linux
+		return ErrScanInterrupt
+	// TODO: Add clauses for other known exit codes we might want to define closer.
+	case errStatus != nil
 		return errStatus
+	default:
 	}
 
 	// Parse nmap xml output. Usually nmap always returns valid XML, even if there is a scan error.

--- a/nmap.go
+++ b/nmap.go
@@ -264,17 +264,22 @@ func (s *Scanner) processNmapResult(result *Run, warnings *[]string, stdout, std
 
 	// Check for errors indicated by context or return code.
 	switch {
-	case errors.Is(s.ctx.Err(), context.DeadlineExceeded):
+	case errors.Is(s.ctx.Err(), context.DeadlineExceeded): // Command context exceeded
 		return ErrScanTimeout
-	case errors.Is(s.ctx.Err(), context.Canceled):
+	case errors.Is(s.ctx.Err(), context.Canceled): // Command context cancelled programmatically
 		return ErrScanInterrupt
-	case errStatus.Error() == "exit status 0xc000013a": // Exit code for ctrl+c on Windows
-		return ErrScanInterrupt
-	case errStatus.Error() == "exit status 130": // Exit code for ctrl+c on Linux
-		return ErrScanInterrupt
-	// TODO: Add clauses for other known exit codes we might want to define closer.
-	case errStatus != nil
-		return errStatus
+	case errStatus != nil: // Error with status code returned by Nmap
+
+		// Return suitable error or pass through original exit status
+		switch {
+		case errStatus.Error() == "exit status 0xc000013a": // Exit code for ctrl+c on Windows
+			return ErrScanInterrupt
+		case errStatus.Error() == "exit status 130": // Exit code for ctrl+c on Linux
+			return ErrScanInterrupt
+		// TODO: Add clauses for other known exit codes we might want to define closer.
+		default:
+			return errStatus
+		}
 	default:
 	}
 


### PR DESCRIPTION
Had to change it again, I got mislead by a deceptive code inspection message of my IDE. I was wondering already, why it would say `errStatus` cannot be nil, obviously it can and even should. 

It seems the IDE was deriving this annotation based on my case statement above, like "Okay, you do not check for nil, so I guess it won't be nil", rather then looking at what could really arrive through the `done` channel... 🤷‍♂️
 
![2025-05-23 10_29_31-Window](https://github.com/user-attachments/assets/e04ff039-f894-4e47-9f70-d75e5f925638)

Obviously, `errStatus` CAN be nil and the call of `.Error()` in the case clauses would make the latest changes ballistic :)

I had to divide the cases up again:

![image](https://github.com/user-attachments/assets/009319ae-945a-416c-aeca-e2c945ee3260)

