### PR TITLE
[WIP & POC] Refactor concurrency into simpler errorgroup design 

### DIFF
--- a/examples/count_hosts_by_os/main.go
+++ b/examples/count_hosts_by_os/main.go
@@ -33,7 +33,7 @@ func main() {
 	countByOS(result)
 }
 
-func countByOS(result *nmap.Run) {
+func countByOS(result nmap.Run) {
 	var (
 		linux, windows int
 	)

--- a/examples/spoof_and_decoys/main.go
+++ b/examples/spoof_and_decoys/main.go
@@ -62,7 +62,7 @@ func main() {
 	printResults(result)
 }
 
-func printResults(result *nmap.Run) {
+func printResults(result nmap.Run) {
 	// Use the results to print an example output
 	for _, host := range result.Hosts {
 		if len(host.Ports) == 0 || len(host.Addresses) == 0 {

--- a/nmap_test.go
+++ b/nmap_test.go
@@ -18,6 +18,8 @@ import (
 
 type testStreamer struct{}
 
+var ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+
 // Write is a function that handles the normal nmap stdout.
 func (c *testStreamer) Write(d []byte) (int, error) {
 	return len(d), nil
@@ -205,11 +207,7 @@ func TestRun(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			ctx := context.Background()
 			if test.testTimeout {
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithTimeout(context.Background(), 99*time.Hour)
-
 				go (func() {
 					// Cancel context to force timeout
 					defer cancel()
@@ -403,11 +401,7 @@ func TestRunAsync(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			ctx := context.Background()
 			if test.testTimeout {
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithTimeout(context.Background(), 99*time.Hour)
-
 				go (func() {
 					// Cancel context to force timeout
 					defer cancel()
@@ -491,7 +485,6 @@ func TestCheckStdErr(t *testing.T) {
 // See: https://github.com/Ullaakut/nmap/issues/122
 func TestParseXMLOutputRaceCondition(t *testing.T) {
 	scans := make(chan int, 100)
-	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	var wg sync.WaitGroup

--- a/nmap_test.go
+++ b/nmap_test.go
@@ -473,7 +473,7 @@ func TestCheckStdErr(t *testing.T) {
 			buf := bytes.Buffer{}
 			_, _ = buf.Write([]byte(test.stderr))
 			var warnings []string
-			err := checkStdErr(&buf, &warnings)
+			warnings, err := checkStdErr(&buf)
 
 			assert.Equal(t, test.expectedErr, err)
 			assert.True(t, reflect.DeepEqual(test.warnings, warnings))

--- a/nmap_test.go
+++ b/nmap_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"reflect"
@@ -255,7 +254,7 @@ func TestRun(t *testing.T) {
 
 func TestRunWithProgress(t *testing.T) {
 	// Open and parse sample result for testing
-	dat, err := ioutil.ReadFile("tests/xml/scan_base.xml")
+	dat, err := os.Open("tests/xml/scan_base.xml")
 	if err != nil {
 		panic(err)
 	}

--- a/xml.go
+++ b/xml.go
@@ -57,7 +57,7 @@ func (r Run) ToReader() io.Reader {
 }
 
 func (r *Run) FromFile(filename string) error {
-	readFile, err := os.ReadFile(filename)
+	readFile, err := os.Open(filename)
 	if err != nil {
 		return err
 	}
@@ -442,10 +442,10 @@ func (t *Timestamp) UnmarshalXMLAttr(attr xml.Attr) (err error) {
 }
 
 // Parse takes a byte array of nmap xml data and unmarshal it into a Run struct.
-func Parse(content []byte, result *Run) error {
-	result.rawXML = content
-
-	err := xml.Unmarshal(content, result)
-
-	return err
+func Parse(content io.Reader, result *Run) error {
+	if contentAll, err := io.ReadAll(content); err != nil {
+		return err
+	} else {
+		return xml.Unmarshal(contentAll, result)
+	}
 }

--- a/xml_test.go
+++ b/xml_test.go
@@ -314,7 +314,7 @@ func TestToFile(t *testing.T) {
 
 func TestToReader(t *testing.T) {
 	inputFile := "tests/xml/scan_base.xml"
-	rawXML, err := ioutil.ReadFile(inputFile)
+	rawXML, err := os.Open(inputFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1081,7 +1081,7 @@ func TestParseRunXML(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.inputFile, func(t *testing.T) {
-			rawXML, err := ioutil.ReadFile(test.inputFile)
+			rawXML, err := os.Open(test.inputFile)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
hi @Ullaakut big thanks this project has been a huge help for a vulners scanner I built. 

The general goal is to reduce state, channels and concurrency to make debugging the core parsing engine more intuitive. 

### High level changes
* favor io.Reader over []byte and reduce bulk copying
* read stdout &stderr with just 2 goroutines instead of many goroutines and channels
* use errgroup over waitgroup for simpler design.
* clean up unnecessary pointers to reduce crashes

### Benefits

* clean out most goroutines and channels
* reduced state and logic to improve debugging.

### Broken
* progress bar support is pending
* rawXML is missing. plan to replace with io.Reader instead of []byte


I understand it's a major reworking of the core component.  If it's desirable, I can restore the missing functionality into a proper PR.  If it's too big a change, I'm happy to close it out. 