### PR TITLE
fix: sysprocattr option

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 )
 
 func (s *Scanner) buildArgs() []string {
@@ -32,6 +33,9 @@ func (s *Scanner) newCmd(ctx context.Context) *exec.Cmd {
 	//nolint:gosec // Arguments are passed directly to nmap; users intentionally control args.
 	cmd := exec.CommandContext(ctx, s.binaryPath, args...)
 	if s.modifySysProcAttr != nil {
+		if cmd.SysProcAttr == nil {
+			cmd.SysProcAttr = &syscall.SysProcAttr{}
+		}
 		s.modifySysProcAttr(cmd.SysProcAttr)
 	}
 	return cmd

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,27 @@
+package nmap
+
+import (
+	"context"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCmdWithCustomSysProcAttrInitializesAndPassesCommandAttribute(t *testing.T) {
+	var callbackAttr *syscall.SysProcAttr
+
+	scanner, err := NewScanner(
+		WithBinaryPath("nmap"),
+		WithCustomSysProcAttr(func(attr *syscall.SysProcAttr) {
+			callbackAttr = attr
+		}),
+	)
+	require.NoError(t, err)
+
+	cmd := scanner.newCmd(context.Background())
+
+	require.NotNil(t, cmd.SysProcAttr)
+	require.NotNil(t, callbackAttr)
+	require.Same(t, cmd.SysProcAttr, callbackAttr)
+}

--- a/nmap.go
+++ b/nmap.go
@@ -22,7 +22,7 @@ type AsyncScanRunner interface {
 	RunAsync(ctx context.Context) (<-chan []byte, <-chan []byte, <-chan RunResult, error)
 }
 
-// Scanner represents n Nmap scanner.
+// Scanner represents an Nmap scanner.
 type Scanner struct {
 	modifySysProcAttr func(*syscall.SysProcAttr)
 


### PR DESCRIPTION
## Goal of this PR

Fixes #155 

Creates an empty struct before calling `modifySysProcAttr`.
Thanks to @roysmanfo for the bug report.

## How did I test it

* Added regression test
* Linter still passes