### PR TITLE
fix: gotestsum in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,9 +56,7 @@ jobs:
           version: v2.7.2
 
       - name: Setup gotestsum
-        uses: gertd/action-gotestsum@v3.0.0
-        with:
-          gotestsum_version: v1.13.0
+        run: go install gotest.tools/gotestsum@v1.13.0
 
       - name: Run Tests
         env: 


### PR DESCRIPTION
## Goal of this PR

Fixes CI workflows following the breakage of `gertd/action-gotestsum` by replacing it with `gotest.tools/gotestsum`.

## How did I test it?

Will do with this PR.